### PR TITLE
fix env setup scripts

### DIFF
--- a/bin/run_collector
+++ b/bin/run_collector
@@ -1,13 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
-#!/usr/bin/env bash
-set -euo pipefail
 export PYENV_ROOT="$HOME/.pyenv"
 export PATH="$PYENV_ROOT/bin:$PATH"
 eval "$(pyenv init -)"
 eval "$(pyenv virtualenv-init -)"
 pyenv activate collector-env
-CO_DIR="${HOME}/trading-bots/collector"
-SCRIPT="${CO_DIR}/collector/normalize_trades.py"
+CO_DIR="$HOME/trading-bots/collector"
+SCRIPT="$CO_DIR/collector/normalize_trades.py"
 cd "$CO_DIR"
 exec python "$SCRIPT" "$@"

--- a/bin/run_freqtrade
+++ b/bin/run_freqtrade
@@ -1,13 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
-#!/usr/bin/env bash
-set -euo pipefail
+
 export PYENV_ROOT="$HOME/.pyenv"
 export PATH="$PYENV_ROOT/bin:$PATH"
 eval "$(pyenv init -)"
 eval "$(pyenv virtualenv-init -)"
 pyenv activate freqtrade-env
-FT_DIR="${HOME}/trading-bots/freqtrade"
-CFG="${FT_DIR}/config/freqtrade/config.json"
+
+FT_DIR="$HOME/trading-bots/freqtrade"
+CFG="$FT_DIR/config/freqtrade/config.json"
 cd "$FT_DIR"
-exec freqtrade trade --dry-run --config /home/nader/trading-bots/freqtrade/config/config.json
+exec freqtrade trade --dry-run --config "$CFG" --strategy EMA_Cross --api-server
+

--- a/bin/run_freqtrade_web
+++ b/bin/run_freqtrade_web
@@ -5,5 +5,8 @@ export PATH="$PYENV_ROOT/bin:$PATH"
 eval "$(pyenv init -)"
 eval "$(pyenv virtualenv-init -)"
 pyenv activate freqtrade-env
-exec freqtrade webserver -c /home/nader/trading-bots/freqtrade/config/config.json
+
+FT_DIR="$HOME/trading-bots/freqtrade"
+CFG="$FT_DIR/config/freqtrade/config.json"
+exec freqtrade webserver -c "$CFG"
 

--- a/bin/run_hummingbot
+++ b/bin/run_hummingbot
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
-#!/usr/bin/env bash
-set -euo pipefail
+
 export PYENV_ROOT="$HOME/.pyenv"
 export PATH="$PYENV_ROOT/bin:$PATH"
 eval "$(pyenv init -)"
 eval "$(pyenv virtualenv-init -)"
 pyenv activate hummingbot-env
-HB_DIR="${HOME}/trading-bots/hummingbot"
-CFG="${HB_DIR}/config/hummingbot/conf_pmm.yml"
+
+HB_DIR="$HOME/trading-bots/hummingbot"
+CFG="$HB_DIR/config/hummingbot/conf_pmm.yml"
 cd "$HB_DIR"
-exec python -m hummingbot --config-file "$CFG"
+exec hummingbot --config-file "$CFG"

--- a/bin/run_jesse
+++ b/bin/run_jesse
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
-#!/usr/bin/env bash
-set -euo pipefail
+
 export PYENV_ROOT="$HOME/.pyenv"
 export PATH="$PYENV_ROOT/bin:$PATH"
 eval "$(pyenv init -)"
 eval "$(pyenv virtualenv-init -)"
 pyenv activate jesse-env
-JE_DIR="${HOME}/trading-bots/jesse"
+
+JE_DIR="$HOME/trading-bots/jesse"
 export JESSE_CONFIG_MODULE="config.jesse.config"
 cd "$JE_DIR"
 exec jesse run

--- a/bin/start_collector
+++ b/bin/start_collector
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 SESSION="collector"
-CMD="bash -lc '/home/nader/bin/run_collector'"
+CMD="bash -lc '$HOME/bin/run_collector'"
 if tmux has-session -t "$SESSION" 2>/dev/null; then
   echo "tmux session '$SESSION' already exists."
 else

--- a/bin/start_freqtrade
+++ b/bin/start_freqtrade
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 SESSION="freqtrade"
-CMD="bash -lc '/home/nader/bin/run_freqtrade'"
+CMD="bash -lc '$HOME/bin/run_freqtrade'"
 if tmux has-session -t "$SESSION" 2>/dev/null; then
   echo "tmux session '$SESSION' already exists."
 else

--- a/bin/start_hummingbot
+++ b/bin/start_hummingbot
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 SESSION="hummingbot"
-CMD="bash -lc '/home/nader/bin/run_hummingbot'"
+CMD="bash -lc '$HOME/bin/run_hummingbot'"
 if tmux has-session -t "$SESSION" 2>/dev/null; then
   echo "tmux session '$SESSION' already exists."
 else

--- a/bin/start_jesse
+++ b/bin/start_jesse
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 SESSION="jesse"
-CMD="bash -lc '/home/nader/bin/run_jesse'"
+CMD="bash -lc '$HOME/bin/run_jesse'"
 if tmux has-session -t "$SESSION" 2>/dev/null; then
   echo "tmux session '$SESSION' already exists."
 else

--- a/bin/start_octobot
+++ b/bin/start_octobot
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 SESSION="octobot"
-CMD="bash -lc '/home/nader/bin/run_octobot'"
+CMD="bash -lc '$HOME/bin/run_octobot'"
 if tmux has-session -t "$SESSION" 2>/dev/null; then
   echo "tmux session '$SESSION' already exists."
 else

--- a/trading-bots/freqtrade/config/freqtrade/config.json
+++ b/trading-bots/freqtrade/config/freqtrade/config.json
@@ -35,7 +35,7 @@
     "username": "user",
     "password": "pass"
   },
-  "datadir": "/home/nader/user_data/data",
-  "user_data_dir": "/home/nader/user_data",
-  "strategy_path": "/home/nader/user_data/strategies"
-}
+    "datadir": "user_data/data",
+    "user_data_dir": "user_data",
+    "strategy_path": "user_data/strategies"
+  }

--- a/trading-bots/jesse/config/jesse/config.py
+++ b/trading-bots/jesse/config/jesse/config.py
@@ -1,0 +1,3 @@
+DATA_STORAGE_PATH = "storage"
+DEBUG_MODE = True
+


### PR DESCRIPTION
## Summary
- clean up start scripts to use HOME paths
- fix run scripts to activate pyenv environments properly
- add portable Freqtrade and Jesse configs

## Testing
- `bash -n bin/start_collector bin/start_freqtrade bin/start_freqtrade_web bin/start_hummingbot bin/start_jesse bin/start_octobot bin/run_collector bin/run_freqtrade bin/run_freqtrade_web bin/run_hummingbot bin/run_jesse bin/run_octobot`
- `python -m json.tool trading-bots/freqtrade/config/freqtrade/config.json`


------
https://chatgpt.com/codex/tasks/task_e_68b08ff07f508327b8a64c84b9793bde