### PR TITLE
Enable shell tracing for startup scripts

### DIFF
--- a/bin/run_collector
+++ b/bin/run_collector
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -euxo pipefail
 export PYENV_ROOT="$HOME/.pyenv"
 export PATH="$PYENV_ROOT/bin:$PATH"
 eval "$(pyenv init -)"

--- a/bin/run_freqtrade
+++ b/bin/run_freqtrade
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -euxo pipefail
 
 export PYENV_ROOT="$HOME/.pyenv"
 export PATH="$PYENV_ROOT/bin:$PATH"

--- a/bin/run_freqtrade_web
+++ b/bin/run_freqtrade_web
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -euxo pipefail
 export PYENV_ROOT="$HOME/.pyenv"
 export PATH="$PYENV_ROOT/bin:$PATH"
 eval "$(pyenv init -)"

--- a/bin/run_hummingbot
+++ b/bin/run_hummingbot
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -euxo pipefail
 
 export PYENV_ROOT="$HOME/.pyenv"
 export PATH="$PYENV_ROOT/bin:$PATH"

--- a/bin/run_jesse
+++ b/bin/run_jesse
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -euxo pipefail
 
 export PYENV_ROOT="$HOME/.pyenv"
 export PATH="$PYENV_ROOT/bin:$PATH"

--- a/bin/run_octobot
+++ b/bin/run_octobot
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -euxo pipefail
 export PYENV_ROOT="$HOME/.pyenv"
 export PATH="$PYENV_ROOT/bin:$PATH"
 eval "$(pyenv init -)"

--- a/bin/start_collector
+++ b/bin/start_collector
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -euxo pipefail
 SESSION="collector"
 CMD="bash -lc '$HOME/bin/run_collector'"
 if tmux has-session -t "$SESSION" 2>/dev/null; then

--- a/bin/start_freqtrade
+++ b/bin/start_freqtrade
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -euxo pipefail
 SESSION="freqtrade"
 CMD="bash -lc '$HOME/bin/run_freqtrade'"
 if tmux has-session -t "$SESSION" 2>/dev/null; then

--- a/bin/start_freqtrade_web
+++ b/bin/start_freqtrade_web
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -euxo pipefail
 SESSION="freqtrade_web"
 CMD="bash -lc '$HOME/bin/run_freqtrade_web 2>&1 | tee -a $HOME/trading-bots/logs/freqtrade_web.log; read -n1 -r -p \"[freqtrade webserver exited] Press any key...\"'"
 mkdir -p "$HOME/trading-bots/logs"

--- a/bin/start_hummingbot
+++ b/bin/start_hummingbot
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -euxo pipefail
 SESSION="hummingbot"
 CMD="bash -lc '$HOME/bin/run_hummingbot'"
 if tmux has-session -t "$SESSION" 2>/dev/null; then

--- a/bin/start_jesse
+++ b/bin/start_jesse
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -euxo pipefail
 SESSION="jesse"
 CMD="bash -lc '$HOME/bin/run_jesse'"
 if tmux has-session -t "$SESSION" 2>/dev/null; then

--- a/bin/start_octobot
+++ b/bin/start_octobot
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -euxo pipefail
 SESSION="octobot"
 CMD="bash -lc '$HOME/bin/run_octobot'"
 if tmux has-session -t "$SESSION" 2>/dev/null; then

--- a/trading-bots/run/run_collector.sh
+++ b/trading-bots/run/run_collector.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -euxo pipefail
 #!/usr/bin/env bash
-set -euo pipefail
+set -euxo pipefail
 export PYENV_ROOT="$HOME/.pyenv"
 export PATH="$PYENV_ROOT/bin:$PATH"
 eval "$(pyenv init -)"

--- a/trading-bots/run/run_freqtrade.sh
+++ b/trading-bots/run/run_freqtrade.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -euxo pipefail
 #!/usr/bin/env bash
-set -euo pipefail
+set -euxo pipefail
 export PYENV_ROOT="$HOME/.pyenv"
 export PATH="$PYENV_ROOT/bin:$PATH"
 eval "$(pyenv init -)"

--- a/trading-bots/run/run_hummingbot.sh
+++ b/trading-bots/run/run_hummingbot.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -euxo pipefail
 #!/usr/bin/env bash
-set -euo pipefail
+set -euxo pipefail
 export PYENV_ROOT="$HOME/.pyenv"
 export PATH="$PYENV_ROOT/bin:$PATH"
 eval "$(pyenv init -)"

--- a/trading-bots/run/run_jesse.sh
+++ b/trading-bots/run/run_jesse.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -euxo pipefail
 #!/usr/bin/env bash
-set -euo pipefail
+set -euxo pipefail
 export PYENV_ROOT="$HOME/.pyenv"
 export PATH="$PYENV_ROOT/bin:$PATH"
 eval "$(pyenv init -)"

--- a/trading-bots/run/run_octobot.sh
+++ b/trading-bots/run/run_octobot.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -euxo pipefail
 export PYENV_ROOT="$HOME/.pyenv"
 export PATH="$PYENV_ROOT/bin:$PATH"
 eval "$(pyenv init -)"

--- a/trading-bots/run/start_collector.sh
+++ b/trading-bots/run/start_collector.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -euxo pipefail
 SESSION="collector"
 CMD="bash -lc '/home/nader/bin/run_collector'"
 if tmux has-session -t "$SESSION" 2>/dev/null; then

--- a/trading-bots/run/start_freqtrade.sh
+++ b/trading-bots/run/start_freqtrade.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -euxo pipefail
 SESSION="freqtrade"
 CMD="bash -lc '/home/nader/bin/run_freqtrade'"
 if tmux has-session -t "$SESSION" 2>/dev/null; then

--- a/trading-bots/run/start_hummingbot.sh
+++ b/trading-bots/run/start_hummingbot.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -euxo pipefail
 SESSION="hummingbot"
 CMD="bash -lc '/home/nader/bin/run_hummingbot'"
 if tmux has-session -t "$SESSION" 2>/dev/null; then

--- a/trading-bots/run/start_jesse.sh
+++ b/trading-bots/run/start_jesse.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -euxo pipefail
 SESSION="jesse"
 CMD="bash -lc '/home/nader/bin/run_jesse'"
 if tmux has-session -t "$SESSION" 2>/dev/null; then

--- a/trading-bots/run/start_octobot.sh
+++ b/trading-bots/run/start_octobot.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -euxo pipefail
 SESSION="octobot"
 CMD="bash -lc '/home/nader/bin/run_octobot'"
 if tmux has-session -t "$SESSION" 2>/dev/null; then


### PR DESCRIPTION
## Summary
- add `-x` tracing to start scripts for debugging session startup
- add `-x` tracing to run scripts to surface early failures

## Testing
- `shellcheck bin/start_* bin/run_* trading-bots/run/start_*.sh trading-bots/run/run_*.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b0918be6608327ae9933a0e3df9da9